### PR TITLE
Fix duplicate initialization of [DEFAULT] Firebase app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'theme/app_theme.dart';
@@ -6,18 +7,22 @@ import 'screens/login_screen.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await Firebase.initializeApp(
-  options: const FirebaseOptions(
-    apiKey: 'AIzaSyAY-2R0EX1vY1T5UTSJSrVLV-whQSmjU1w',
-    appId: '1:342791532648:web:85714f4e0b1c238cb6cbdd',
-    messagingSenderId: '342791532648',
-    projectId: 'tindahanap',
-    authDomain: 'tindahanap.firebaseapp.com',
-    storageBucket: 'tindahanap.appspot.com',
-    measurementId: 'G-DST5DB9KXB',
-  ),
-);
-
+  if (kIsWeb) {
+    await Firebase.initializeApp(
+      options: const FirebaseOptions(
+        apiKey: 'AIzaSyAY-2R0EX1vY1T5UTSJSrVLV-whQSmjU1w',
+        appId: '1:342791532648:web:85714f4e0b1c238cb6cbdd',
+        messagingSenderId: '342791532648',
+        projectId: 'tindahanap',
+        authDomain: 'tindahanap.firebaseapp.com',
+        storageBucket: 'tindahanap.appspot.com',
+        measurementId: 'G-DST5DB9KXB',
+      ),
+    );
+  } else {
+    // Android: Use google-services.json
+    await Firebase.initializeApp();
+  }
 
   runApp(const TindahanapApp());
 }


### PR DESCRIPTION
Building for Android uses google-services.json to automatically create a [DEFAULT] Firebase app. Explicitly calling Firebase.initializeApp() in main without supplying a name argument creates another [DEFAULT] Firebase app, resulting in a duplicate app and throwing an error.

This adds a check for the build platform so Android can use google-services.json for default initialization. Web builds can continue running normally as before using the call to Firebase.initializeApp() in main.

## Summary by Sourcery

Modify Firebase initialization to prevent duplicate app creation across different platforms

Bug Fixes:
- Prevent duplicate Firebase app initialization on Android by conditionally initializing based on platform

Enhancements:
- Add platform-specific Firebase initialization logic to support both web and mobile platforms