### PR TITLE
Resize favorite button on Favorites screen

### DIFF
--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -134,13 +134,19 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
             child: StoreCard(store: stores[index]),
           ),
           Positioned(
-            top: 8.0,
-            right: 8.0,
-            child: IconButton.filledTonal(
-              onPressed: () {},
-              isSelected: true,
-              selectedIcon: const Icon(Icons.favorite),
-              icon: const Icon(Icons.favorite_outline),
+            top: 12.0,
+            right: 12.0,
+            child: SizedBox(
+              width: 28.0,
+              height: 28.0,
+              child: IconButton.filledTonal(
+                iconSize: 20.0,
+                padding: EdgeInsets.zero,
+                onPressed: () {},
+                isSelected: true,
+                selectedIcon: const Icon(Icons.favorite),
+                icon: const Icon(Icons.favorite_outline),
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary by Sourcery

Adjust the size and position of the favorite button on store cards in the favorites screen.

Enhancements:
- Resize the favorite button on store cards.
- Reposition the favorite button on store cards.